### PR TITLE
vendorsetup: point to a more complete device list

### DIFF
--- a/vendorsetup.sh
+++ b/vendorsetup.sh
@@ -1,4 +1,4 @@
-for combo in $(curl -s https://raw.githubusercontent.com/LineageOS/hudson/master/lineage-build-targets | sed -e 's/#.*$//' | grep cm-14.1 | awk '{printf "lineage_%s-%s\n", $1, $2}')
+for combo in $(curl -s https://raw.githubusercontent.com/DespairFactor/build_targets/master/lineage-build-targets | sed -e 's/#.*$//' | grep cm-14.1 | awk '{printf "lineage_%s-%s\n", $1, $2}')
 do
     add_lunch_combo $combo
 done


### PR DESCRIPTION
This will allow us to build marlin/sailfish and can be maintained to add more devices to the support list